### PR TITLE
Add University Controller and Tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
@@ -1,9 +1,39 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
+import edu.ucsb.cs156.spring.backenddemo.services.UniversityQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+@Tag(name = "University info from universities.hipolabs.com")
+@Slf4j
 @RestController
+@RequestMapping("/api/university")
 public class UniversityController {
-    
+
+  ObjectMapper mapper = new ObjectMapper();
+
+  @Autowired
+  UniversityQueryService universityQueryService;
+
+  @Operation(summary = "Get list of universities that match a given name", description = "Uses API documented here: http://universities.hipolabs.com/search")
+  @GetMapping("/get")
+  public ResponseEntity<String> getUniversity(
+      @Parameter(name = "name", description = "name to search", example = "'Harvard' or 'Stanford'") @RequestParam String name)
+      throws JsonProcessingException {
+    log.info("getUniversity: university={}", name);
+    String result = universityQueryService.getJSON(name);
+    return ResponseEntity.ok().body(result);
+  }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityControllerTests.java
@@ -1,0 +1,42 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.UniversityQueryService;
+
+@WebMvcTest(value = UniversityController.class)
+public class UniversityControllerTests {
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  UniversityQueryService mockUniversityQueryService;
+
+  @Test
+  public void test_getUniversities() throws Exception {
+
+    String fakeJsonResult = "{ \"fake\" : \"result\" }";
+    String university = "UCSB";
+    when(mockUniversityQueryService.getJSON(eq(university))).thenReturn(fakeJsonResult);
+
+    String url = String.format("/api/university/get?name=%s", university);
+
+    MvcResult response = mockMvc
+        .perform(get(url).contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(fakeJsonResult, responseString);
+  }
+}


### PR DESCRIPTION
In this PR, I added a controller for the University Service (our wrapper for the HipoLabs Universities API) which includes documentation for Swagger. This service allows you to get a list of universities that match the given query and some details about the universities such as their website.

Here is a dev deployment to try it out: http://team01-jakedel-dev.dokku-05.cs.ucsb.edu/api/university/get?name=stanford

Closes https://github.com/ucsb-cs156-f23/team01-f23-6pm-1/issues/15